### PR TITLE
fix: add missing enabled field to test_scenarios table

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -230,6 +230,7 @@ model test_scenarios {
   input              String
   expected_output    String
   category           String?
+  enabled            Boolean              @default(true)
   created_at         DateTime?            @default(now()) @db.Timestamptz(6)
   updated_at         DateTime?            @default(now()) @db.Timestamptz(6)
   test_conversations test_conversations[]


### PR DESCRIPTION
- Added enabled Boolean field with default value true to test_scenarios model
- This fixes the scenario enable/disable toggle functionality
- Applied schema changes to database